### PR TITLE
Migrate from DSL1 to DSL2

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -112,19 +112,8 @@ log.info ""
 
 
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-                                      MAIN
+                                    PROCESSES
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
-
-Channel
-	.fromPath( fqdir + "/*${params.fastq_pattern}" )
-	.ifEmpty { error "No fastq file matching \'${params.fastq_pattern}\' in: ${fqdir}" }
-	.map { fq -> [
-		file(fq).getName().replaceAll("${params.fastq_pattern}\$",''),
-		file(fq)
-	]}
-	.view()
-	.into { reads_ch; reads_ch2; reads_ch3 }
-
 
 process fastqc {
 	tag { sample_id }
@@ -133,11 +122,11 @@ process fastqc {
 	publishDir "${outdir}/fastqc/zip", mode: 'copy', pattern: '*_fastqc.zip', enabled : params.fastqcoutput
 
 	input:
-	set sample_id, file(reads) from reads_ch
+	tuple val(sample_id), file(reads)
 
 	output:
 	file "*_fastqc.html"
-	file "*_fastqc.zip" into fastqc_ch, fastqc_ch2
+	path "*_fastqc.zip"
 
 	"""
 	fastqc --threads ${params.fastqc_threads} \\
@@ -152,11 +141,11 @@ process trim {
 	publishDir "${outdir}/trimmomatic/logs", mode: 'copy', pattern : "${sample_id}.trimmomatic.stats.log", enabled : params.trimoutput
 
 	input:
-	set sample_id, file(reads) from reads_ch2
+	tuple val(sample_id), file(reads) 
 
 	output:
-	set sample_id, file("${sample_id}.trim.fastq.gz") into trimmed_files, trimmed_files2
-	file("${sample_id}.trimmomatic.stats.log") into trimmomatic_logs, trimmomatic_logs2
+	tuple val(sample_id), file("${sample_id}.trim.fastq.gz"), emit: trim_files
+	file("${sample_id}.trimmomatic.stats.log")
 
 	"""
 	trimmomatic SE -phred33 -threads ${params.trimmo_threads} \\
@@ -176,11 +165,11 @@ process bowtie2 {
 	publishDir "${outdir}/bowtie2/logs", mode: 'copy', pattern : "${sample_id}.bowtie2.stats.log", enabled: params.bowtieoutput
 
 	input:
-	set sample_id, file(reads) from trimmed_files
+	tuple val(sample_id), file(reads)
 
 	output:
-	set sample_id, file("${sample_id}.sam") into bowtie_files
-	file("${sample_id}.bowtie2.stats.log") into bowtie_logs, bowtie_logs2
+	tuple val(sample_id), file("${sample_id}.sam"), emit: aligned_files
+	file("${sample_id}.bowtie2.stats.log") 
 
 	"""
 	bowtie2 -x ${params.bowtie_index} --threads ${params.bowtie_threads} \\
@@ -188,16 +177,16 @@ process bowtie2 {
 	"""
 }
 
-process filter {
+process filter_sam {
 	tag { sample_id }
 
 	publishDir "${outdir}/bowtie2", mode: 'copy', pattern : "${sample_id}.uniq.{bam,bam.bai}", enabled : params.samtoolsoutput
 
 	input:
-	set sample_id, file(sam) from bowtie_files
+	tuple val(sample_id), file(sam)
 
 	output:
-	set sample_id, file("${sample_id}.uniq.bam") into filtered_bam_ch
+	tuple val(sample_id), file("${sample_id}.uniq.bam"), emit: filtered_files
 
 	"""
 	set -o pipefail
@@ -231,11 +220,11 @@ process counts {
 	publishDir "${outdir}/counts/3p/", mode:'copy', pattern: "${sample_id}.3_counts.csv", enabled: params.threeendcount
 
 	input:
-	set sample_id, file(filtered_bam) from filtered_bam_ch
+	tuple val(sample_id), file(filtered_bam)
 
 	output:
-	set sample_id, file("${sample_id}.5_counts.csv"), file("${sample_id}.3_counts.csv") into counts_ch
-	set sample_id, file("${sample_id}.5_counts.csv") into counts_ch2
+	//tuple val(sample_id), file("${sample_id}.5_counts.csv"), file("${sample_id}.3_counts.csv"), emit: allcounts_files
+	tuple val(sample_id), file("${sample_id}.5_counts.csv"), emit: 5counts_files
 	script:
 	"""
 	bedtools genomecov -d -3 -ibam ${filtered_bam} > ${sample_id}.3_counts.csv
@@ -280,6 +269,25 @@ process report {
 	"""
 	Rscript ${baseDir}/Rscripts/QC/generate_report.R .
 	"""
+}
+
+/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+                                      WORKFLOW
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+
+workflow {
+    fastq_files = Channel
+		.fromPath( fqdir + "/*${params.fastq_pattern}" )
+		.ifEmpty { error "No fastq file matching \'${params.fastq_pattern}\' in: ${fqdir}" }
+		.map { fq -> [
+			file(fq).getName().replaceAll("${params.fastq_pattern}\$",''),
+			file(fq)
+		]}
+    fastqc(fastq_files)
+	trim(fastq_files)
+	bowtie2(trim.out.trim_files)
+	filter_sam(bowtie2.out.aligned_files)
+	counts(filter_sam.out.filtered_files)
 }
 
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/main.nf
+++ b/main.nf
@@ -241,7 +241,7 @@ process split {
 	when: params.split
 
 	input:
-	set sample_id, file(counts5), file(counts3) from counts_ch
+	tuple val(sample_id), file(counts5), file(counts3)
 
 	output:
 	file("${sample_id}.58S.csv")
@@ -289,6 +289,9 @@ workflow {
 	bowtie2(trim.out.trim_files)
 	filter_sam(bowtie2.out.aligned_files)
 	counts(filter_sam.out.filtered_files)
+	if(params.split) {
+		split(counts.out[0])
+	}
 	multiqc(fastqc.out[1].collect(),trim.out[1].collect(),bowtie2.out[1].collect())
 	report(counts.out[1].collect())
 }

--- a/main.nf
+++ b/main.nf
@@ -1,6 +1,6 @@
 #!/usr/bin/env nextflow
 
-// Copyright (C) 2022 CRCL
+// Copyright (C) 2023 CRCL
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,7 +36,7 @@ profiles {
 		conda.enabled = true
 
 		process {
-			withName: 'fastqc|trim|bowtie2|filter|multiqc|counts' {
+			withName: 'fastqc|trim|bowtie2|filter_sam|multiqc|counts' {
 				conda = "$baseDir/docker/rms-processing.yml"
 			 // conda = "/path/to/your/conda/envs/rms-processing"
 			}

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,10 +1,10 @@
 manifest {
-	homePage = 'https://github.com/EpiRnaTools/ribomethseq-nf'
+	homePage = 'https://github.com/RibosomeCRCL/ribomethseq-nf'
 	description = 'RiboMethSeq data processing'
 	mainScript = 'main.nf'
 	name = 'ribomethseq-nf'
 	author = 'Hermes Paraqindes, Theo Combe'
-	version = '1.0'
+	version = '1.5'
 }
 
 /***************************************************************/

--- a/nf-config/exec.config
+++ b/nf-config/exec.config
@@ -18,7 +18,7 @@ process {
 	withName: 'trim'    {cpus = params.trimmo_threads; time = '4h'}
 	withName: 'multiqc' {cpus = 2; time = '1h'}
 	withName: 'bowtie2' {cpus = params.bowtie_threads; memory = 12.GB; time = '12h'}
-	withName: 'filter'  {cpus = params.samtools_threads; memory = 12.GB; time = '6h'}
+	withName: 'filter_sam'  {cpus = params.samtools_threads; memory = 12.GB; time = '6h'}
 	withName: 'counts'  {cpus = 2; memory = 12.GB}
 	withName: 'split'   {cpus = 4; memory = 4.GB}
 	withName: 'report'  {cpus = 2; time = '1h'}


### PR DESCRIPTION
I have made the necessary changes to migrate to DSL2.

Main changes : 
- There is now a workflow in main.nf, as required in DSL2.
- `filter` has been renamed to `filter_sam`, as the previous name was conflicting with one of Nextflow's functions.

Minor changes : 

- Parts of main.nf were using the deprecated DSL1 syntax and are now updated to DSL2. Most modifications are related to channels, input and output handling in processes.

Unless there is a bug, the behavior of ribomethseq-nf should be unaffected by this update.